### PR TITLE
Update docs to include full uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ class StoreDeviceRequest extends FormRequest
 The `ExpoChannel` expects you to return an instance of `ExpoPushToken` from your `Notifiable`s. You can easily achieve this by applying the `ExpoPushToken` as a custom model cast. An example:
 
 ```php
-use NotificationChannels\Expo\AsExpoPushToken;
+use NotificationChannels\Expo\ExpoPushToken;
 
 class User extends Authenticatable
 {
@@ -199,7 +199,7 @@ class User extends Authenticatable
     protected function casts(): array
     {
         return [
-            'expo_token' => AsExpoPushToken::class
+            'expo_token' => ExpoPushToken::class
         ];
     }
 }


### PR DESCRIPTION
While implementing this on a new app I was working through the docs and realised I would have liked to see the full class names for the referenced objects so they could be copied into my app.

* Include `use` statements in the doc blocks to make them easy to copy,
* Updated the `$casts` property to use the new `casts()` method with Laravel 11,
* Removed `final` from code samples as it's unnecessary noise

---

One thing I did notice is that there is an inconsistency in the docs when talking about casts. One example uses `ExpoPushToken` as the cast while another uses `AsExpoPushToken`. I thought they were different and was confused but later realised that `ExpoPushToken` defers to `AsExpoPushToken` under the hood.

I wonder if we should remove `AsExpoPushToken` from the docs and instead just refer to `ExpoPushToken` - what do you think?