### PR TITLE
Add contentAvailable property and related methods to ExpoMessage

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -114,6 +114,16 @@ final class ExpoMessage implements Arrayable, JsonSerializable
     private bool $mutableContent = false;
 
     /**
+     * When this is set to true, the notification will cause the iOS app to start in the background to run a background task.
+     * Your app needs to be configured to support this.
+     *
+     * @see https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format Content Available
+     *
+     * iOS only.
+     */
+    private ?bool $contentAvailable = null;
+
+    /**
      * Create a new ExpoMessage instance.
      */
     private function __construct(string $title, string $body)
@@ -293,6 +303,18 @@ final class ExpoMessage implements Arrayable, JsonSerializable
     }
 
     /**
+     * Set whether the notification should cause the iOS app to start in the background.
+     *
+     * @see ExpoMessage::$contentAvailable
+     */
+    public function contentAvailable(bool $value = true): self
+    {
+        $this->contentAvailable = $value;
+
+        return $this;
+    }
+
+    /**
      * Set the delivery priority of the message to 'normal'.
      *
      * @see ExpoMessage::$priority
@@ -411,6 +433,14 @@ final class ExpoMessage implements Arrayable, JsonSerializable
      */
     public function toArray(): array
     {
-        return array_filter(get_object_vars($this), filled(...));
+        $vars = get_object_vars($this);
+
+        // Rename contentAvailable to _contentAvailable for API compatibility
+        if (array_key_exists('contentAvailable', $vars)) {
+            $vars['_contentAvailable'] = $vars['contentAvailable'];
+            unset($vars['contentAvailable']);
+        }
+
+        return array_filter($vars, filled(...));
     }
 }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -121,7 +121,7 @@ final class ExpoMessage implements Arrayable, JsonSerializable
      *
      * iOS only.
      */
-    private ?bool $contentAvailable = null;
+    private ?bool $_contentAvailable = null;
 
     /**
      * Create a new ExpoMessage instance.
@@ -305,11 +305,11 @@ final class ExpoMessage implements Arrayable, JsonSerializable
     /**
      * Set whether the notification should cause the iOS app to start in the background.
      *
-     * @see ExpoMessage::$contentAvailable
+     * @see ExpoMessage::$_contentAvailable
      */
     public function contentAvailable(bool $value = true): self
     {
-        $this->contentAvailable = $value;
+        $this->_contentAvailable = $value;
 
         return $this;
     }
@@ -433,14 +433,6 @@ final class ExpoMessage implements Arrayable, JsonSerializable
      */
     public function toArray(): array
     {
-        $vars = get_object_vars($this);
-
-        // Rename contentAvailable to _contentAvailable for API compatibility
-        if (array_key_exists('contentAvailable', $vars)) {
-            $vars['_contentAvailable'] = $vars['contentAvailable'];
-            unset($vars['contentAvailable']);
-        }
-
-        return array_filter($vars, filled(...));
+        return array_filter(get_object_vars($this), filled(...));
     }
 }

--- a/tests/Unit/ExpoMessageTest.php
+++ b/tests/Unit/ExpoMessageTest.php
@@ -183,6 +183,26 @@ final class ExpoMessageTest extends TestCase
     }
 
     #[Test]
+    public function it_can_set_the_content_available(): void
+    {
+        $msg = ExpoMessage::create()->contentAvailable();
+
+        ['_contentAvailable' => $contentAvailable] = $msg->toArray();
+
+        $this->assertTrue($contentAvailable);
+    }
+
+    #[Test]
+    public function it_can_set_the_content_available_to_false(): void
+    {
+        $msg = ExpoMessage::create()->contentAvailable(false);
+
+        ['_contentAvailable' => $contentAvailable] = $msg->toArray();
+
+        $this->assertFalse($contentAvailable);
+    }
+
+    #[Test]
     public function it_can_set_the_priority_to_normal(): void
     {
         $msgA = ExpoMessage::create()->normal();
@@ -312,6 +332,28 @@ final class ExpoMessageTest extends TestCase
         ], $arrayable);
 
         $this->assertSame($data, $jsonSerializable);
+    }
+
+    #[Test]
+    public function it_includes_content_available_in_array_when_set(): void
+    {
+        $msg = ExpoMessage::create('Background', 'Notification')
+            ->contentAvailable();
+
+        $array = $msg->toArray();
+
+        $this->assertArrayHasKey('_contentAvailable', $array);
+        $this->assertTrue($array['_contentAvailable']);
+    }
+
+    #[Test]
+    public function it_excludes_content_available_from_array_when_not_set(): void
+    {
+        $msg = ExpoMessage::create('Regular', 'Notification');
+
+        $array = $msg->toArray();
+
+        $this->assertArrayNotHasKey('_contentAvailable', $array);
     }
 }
 


### PR DESCRIPTION
According to the Expo documentation (https://docs.expo.dev/versions/latest/sdk/notifications/#headless-background-notifications), push messages should contain the _contentAvailable attribute set to true for headless notifications to work on IOS devices.

I added this new contentAvailable attribute to the code as well as the contentAvailable method following the existing naming.