### PR TITLE
Add rich content (image) support to ExpoMessage

### DIFF
--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -124,6 +124,15 @@ final class ExpoMessage implements Arrayable, JsonSerializable
     private ?bool $_contentAvailable = null;
 
     /**
+     * Rich content to display in the notification, such as an image.
+     * The image must be a publicly accessible URL.
+     * On iOS, displaying the image requires a Notification Service Extension in your app.
+     *
+     * @see https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format
+     */
+    private ?array $richContent = null;
+
+    /**
      * Create a new ExpoMessage instance.
      */
     private function __construct(string $title, string $body)
@@ -354,6 +363,26 @@ final class ExpoMessage implements Arrayable, JsonSerializable
         }
 
         $this->priority = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set rich content to display in the notification.
+     * Currently, only an image URL is supported.
+     *
+     * @throws InvalidArgumentException()
+     *
+     * @see ExpoMessage::$richContent
+     * @see https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format
+     */
+    public function richContent(string $imageUrl): self
+    {
+        if (empty($imageUrl)) {
+            throw new InvalidArgumentException('The image URL must not be empty.');
+        }
+
+        $this->richContent = ['image' => $imageUrl];
 
         return $this;
     }

--- a/tests/Unit/ExpoMessageTest.php
+++ b/tests/Unit/ExpoMessageTest.php
@@ -245,6 +245,25 @@ final class ExpoMessageTest extends TestCase
     }
 
     #[Test]
+    public function it_can_set_rich_content(): void
+    {
+        $msg = ExpoMessage::create()->richContent($value = 'https://example.com/image.png');
+
+        ['richContent' => $richContent] = $msg->toArray();
+
+        $this->assertSame(['image' => $value], $richContent);
+    }
+
+    #[Test]
+    public function it_doesnt_allow_an_empty_rich_content_image_url(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The image URL must not be empty.');
+
+        ExpoMessage::create()->richContent('');
+    }
+
+    #[Test]
     public function it_can_set_a_subtitle(): void
     {
         $msg = ExpoMessage::create()->subtitle($value = "You can't see me");


### PR DESCRIPTION
 Adds a `richContent()` method to `ExpoMessage` that sets an image URL on the notification payload, using the `richContent.image` field supported by the Expo push API.                                                                
                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                       
  - On iOS, displaying the image requires a [Notification Service Extension](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format) in the app, I added a note in the docblock
  - Includes tests